### PR TITLE
fix:修复获取 adGroup 报错 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
  test
  config.toml
  .vim
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 百度营销 MarketingAPI Golang SDK
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/bububa/baidu-marketing.svg)](https://pkg.go.dev/github.com/bububa/baidu-marketing)
-[![Go](https://github.com/bububa/baidu-marketing/actions/workflows/go.yml/badge.svg)](https://github.com/bububa/baidu-marketing/actions/workflows/go.yml)
-[![goreleaser](https://github.com/bububa/baidu-marketing/actions/workflows/goreleaser.yml/badge.svg)](https://github.com/bububa/baidu-marketing/actions/workflows/goreleaser.yml)
-[![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/bububa/baidu-marketing.svg)](https://github.com/bububa/baidu-marketing)
-[![GoReportCard](https://goreportcard.com/badge/github.com/bububa/baidu-marketing)](https://goreportcard.com/report/github.com/bububa/baidu-marketing)
-[![GitHub license](https://img.shields.io/github/license/bububa/baidu-marketing.svg)](https://github.com/bububa/baidu-marketing/blob/master/LICENSE)
-[![GitHub release](https://img.shields.io/github/release/bububa/baidu-marketing.svg)](https://GitHub.com/bububa/baidu-marketing/releases/)
+[![Go Reference](https://pkg.go.dev/badge/github.com/xiaoshouchen/baidu-marketing.svg)](https://pkg.go.dev/github.com/xiaoshouchen/baidu-marketing)
+[![Go](https://github.com/xiaoshouchen/baidu-marketing/actions/workflows/go.yml/badge.svg)](https://github.com/xiaoshouchen/baidu-marketing/actions/workflows/go.yml)
+[![goreleaser](https://github.com/xiaoshouchen/baidu-marketing/actions/workflows/goreleaser.yml/badge.svg)](https://github.com/xiaoshouchen/baidu-marketing/actions/workflows/goreleaser.yml)
+[![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/xiaoshouchen/baidu-marketing.svg)](https://github.com/xiaoshouchen/baidu-marketing)
+[![GoReportCard](https://goreportcard.com/badge/github.com/xiaoshouchen/baidu-marketing)](https://goreportcard.com/report/github.com/xiaoshouchen/baidu-marketing)
+[![GitHub license](https://img.shields.io/github/license/xiaoshouchen/baidu-marketing.svg)](https://github.com/xiaoshouchen/baidu-marketing/blob/master/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/xiaoshouchen/baidu-marketing.svg)](https://GitHub.com/xiaoshouchen/baidu-marketing/releases/)
 
 - OAuth授权 (api/oauth)
   - 换取授权令牌接口 [ AccessToken(clt *core.SDKClient, req *oauth.AccessTokenRequest) (*oauth.AccessToken, error) ]

--- a/api/account/balance/getAccountTransferHistory.go
+++ b/api/account/balance/getAccountTransferHistory.go
@@ -3,9 +3,9 @@ package balance
 import (
 	"time"
 
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/account/balance"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/account/balance"
 )
 
 // GetAccountTransferHistory 查询转账记录

--- a/api/account/balance/getBalanceInfo.go
+++ b/api/account/balance/getBalanceInfo.go
@@ -1,9 +1,9 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/account/balance"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/account/balance"
 )
 
 // GetBalanceInfo 查询账户余额成分

--- a/api/account/balance/getPaymentHistory.go
+++ b/api/account/balance/getPaymentHistory.go
@@ -1,9 +1,9 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/account/balance"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/account/balance"
 )
 
 // GetPaymentHistory 查询待加款信息

--- a/api/account/balance/getPaymentRecord.go
+++ b/api/account/balance/getPaymentRecord.go
@@ -1,9 +1,9 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/account/balance"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/account/balance"
 )
 
 // GetPaymentRecord 查询付款信息与待加款信息

--- a/api/account/getUserListByMccid.go
+++ b/api/account/getUserListByMccid.go
@@ -1,9 +1,9 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/account"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/account"
 )
 
 // GetUserListByMccid 账户管家管理

--- a/api/asset/image/getImage.go
+++ b/api/asset/image/getImage.go
@@ -1,9 +1,9 @@
 package image
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/asset/image"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/asset/image"
 )
 
 // GetImage 通过图片规格、大小、格式、时间区间等条件，筛选出合适的图片返回

--- a/api/asset/newimage/uploadImage.go
+++ b/api/asset/newimage/uploadImage.go
@@ -1,9 +1,9 @@
 package newimage
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	image2 "github.com/bububa/baidu-marketing/model/asset/newimage"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	image2 "github.com/xiaoshouchen/baidu-marketing/model/asset/newimage"
 )
 
 // UploadImage 图片上传接口，上传后搜索推广与信息流推广可共用。上传时不限制单张图片大小，单次请求不超过10M。

--- a/api/asset/video/getVideo.go
+++ b/api/asset/video/getVideo.go
@@ -1,9 +1,9 @@
 package video
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/asset/video"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/asset/video"
 )
 
 // GetVideo 获取信息流&搜索视频素材信息，括视频id、规格、大小、格式、上传日期、最后修改时间、长度、名称、视频URL等等

--- a/api/feed/account/getAccountFeed.go
+++ b/api/feed/account/getAccountFeed.go
@@ -1,9 +1,9 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/account"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/account"
 )
 
 // GetAccountFeed 查询账户

--- a/api/feed/account/updateAccountFeed.go
+++ b/api/feed/account/updateAccountFeed.go
@@ -1,9 +1,9 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/account"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/account"
 )
 
 // UpdateAccountFeed 更新账户信息

--- a/api/feed/adgroup/addAdgroup.go
+++ b/api/feed/adgroup/addAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup"
 )
 
 // AddAdgroup 添加单元

--- a/api/feed/adgroup/deleteAdgroup.go
+++ b/api/feed/adgroup/deleteAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup"
 )
 
 // DeleteAdgroup 删除单元

--- a/api/feed/adgroup/getAdgroup.go
+++ b/api/feed/adgroup/getAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup"
 )
 
 // GetAdgroup 查询单元

--- a/api/feed/adgroup/trans/addOcpcTransFeed.go
+++ b/api/feed/adgroup/trans/addOcpcTransFeed.go
@@ -1,9 +1,9 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup/trans"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup/trans"
 )
 
 // AddOcpcTransFeed 添加转化追踪

--- a/api/feed/adgroup/trans/getOcpcTransFeed.go
+++ b/api/feed/adgroup/trans/getOcpcTransFeed.go
@@ -1,9 +1,9 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup/trans"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup/trans"
 )
 
 // GetOcpcTransFeed 查询转化追踪

--- a/api/feed/adgroup/trans/updateOcpcTransFeed.go
+++ b/api/feed/adgroup/trans/updateOcpcTransFeed.go
@@ -1,9 +1,9 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup/trans"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup/trans"
 )
 
 // UpdateOcpcTransFeed 修改转化追踪

--- a/api/feed/adgroup/updateAdgroup.go
+++ b/api/feed/adgroup/updateAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/adgroup"
 )
 
 // UpdateAdgroup 更新单元

--- a/api/feed/campaign/addCampaign.go
+++ b/api/feed/campaign/addCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/campaign"
 )
 
 // AddCampaign 添加计划

--- a/api/feed/campaign/deleteCampaign.go
+++ b/api/feed/campaign/deleteCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/campaign"
 )
 
 // DeleteCampaign 删除计划

--- a/api/feed/campaign/getCampaign.go
+++ b/api/feed/campaign/getCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/campaign"
 )
 
 // GetCampaign 查询计划

--- a/api/feed/campaign/getJsKpAppList.go
+++ b/api/feed/campaign/getJsKpAppList.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/campaign"
 )
 
 // GetJskAppList 查询计划

--- a/api/feed/campaign/updateCampaign.go
+++ b/api/feed/campaign/updateCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/campaign"
 )
 
 // UpdateCampaign 更新计划

--- a/api/feed/creative/addCreative.go
+++ b/api/feed/creative/addCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/creative"
 )
 
 // AddCreative 新增推广创意

--- a/api/feed/creative/deleteCreative.go
+++ b/api/feed/creative/deleteCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/creative"
 )
 
 // DeleteCreative 删除推广创意

--- a/api/feed/creative/getCreativeFeed.go
+++ b/api/feed/creative/getCreativeFeed.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/creative"
 )
 
 // GetCreativeFeed 查询创意

--- a/api/feed/creative/updateCreative.go
+++ b/api/feed/creative/updateCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/feed/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/feed/creative"
 )
 
 // UpdateCreative 修改推广创意

--- a/api/oauth/accessToken.go
+++ b/api/oauth/accessToken.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model/oauth"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model/oauth"
 )
 
 // AccessToken 换取授权令牌接口

--- a/api/oauth/getUserInfo.go
+++ b/api/oauth/getUserInfo.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model/oauth"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model/oauth"
 )
 
 // GetUserInfo 查询授权用户信息

--- a/api/oauth/refreshToken.go
+++ b/api/oauth/refreshToken.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model/oauth"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model/oauth"
 )
 
 // RefreshToken 更新授权令牌接口

--- a/api/ocpc/actionCb.go
+++ b/api/ocpc/actionCb.go
@@ -1,8 +1,8 @@
 package ocpc
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
 )
 
 // ActionCb APP转化数据收集

--- a/api/ocpc/clickmonitor.go
+++ b/api/ocpc/clickmonitor.go
@@ -1,6 +1,6 @@
 package ocpc
 
-import "github.com/bububa/baidu-marketing/util"
+import "github.com/xiaoshouchen/baidu-marketing/util"
 
 var defaultFields = map[string]string{
 	"advertiser_id": "__USER_ID__",

--- a/api/ocpc/uploadConvertData.go
+++ b/api/ocpc/uploadConvertData.go
@@ -1,9 +1,9 @@
 package ocpc
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/ocpc"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/ocpc"
 )
 
 // UploadConvertData 广告主回传转化数据接口

--- a/api/ocpc/uploadInvalidConvertData.go
+++ b/api/ocpc/uploadInvalidConvertData.go
@@ -1,9 +1,9 @@
 package ocpc
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/ocpc"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/ocpc"
 )
 
 // UploadInvalidConvertData 广告主回传无效转化数据接口

--- a/api/report/createReportTask.go
+++ b/api/report/createReportTask.go
@@ -1,9 +1,9 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // CreateReportTask 创建异步任务

--- a/api/report/feed/account.go
+++ b/api/report/feed/account.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Account 账户报告

--- a/api/report/feed/adgroup.go
+++ b/api/report/feed/adgroup.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Adgroup 单元报告

--- a/api/report/feed/campaign.go
+++ b/api/report/feed/campaign.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Campaign 计划报告

--- a/api/report/feed/creative.go
+++ b/api/report/feed/creative.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Creative 创意报告

--- a/api/report/feed/image.go
+++ b/api/report/feed/image.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Image 图片报告

--- a/api/report/feed/landingPage.go
+++ b/api/report/feed/landingPage.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // LandingPage 落地页报告

--- a/api/report/feed/overall.go
+++ b/api/report/feed/overall.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Overall 信息流整体账户报告

--- a/api/report/feed/product.go
+++ b/api/report/feed/product.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Product 信息流商品报告

--- a/api/report/feed/video.go
+++ b/api/report/feed/video.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Video 视频报告

--- a/api/report/feed/visitor.go
+++ b/api/report/feed/visitor.go
@@ -1,10 +1,10 @@
 package feed
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Visitor 信息流访客明细报告

--- a/api/report/getReportData.go
+++ b/api/report/getReportData.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetReportData 一站式多渠道报告
-func GetReportData(clt *core.SDKClient, auth *model.RequestHeader, reportRequest *report.GetReportDataRequest) (*model.ResponseHeader, *report.ReportData, error) {
+func GetReportData(clt *core.SDKClient, auth *model.RequestHeader, reportRequest *report.GetReportDataRequest) (*model.ResponseHeader, []report.ReportData, error) {
 	req := &model.Request{
 		Header: auth,
 		Body:   reportRequest,

--- a/api/report/getReportData.go
+++ b/api/report/getReportData.go
@@ -1,9 +1,9 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // GetReportData 一站式多渠道报告

--- a/api/report/getTaskStatus.go
+++ b/api/report/getTaskStatus.go
@@ -1,9 +1,9 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // GetTaskStatus 获取任务状态和结果

--- a/api/report/search/account.go
+++ b/api/report/search/account.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Account 账户报告

--- a/api/report/search/adgroup.go
+++ b/api/report/search/adgroup.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Adgroup 单元报告

--- a/api/report/search/audience.go
+++ b/api/report/search/audience.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Audience 人群报告

--- a/api/report/search/campaign.go
+++ b/api/report/search/campaign.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Campaign 计划报告

--- a/api/report/search/creative.go
+++ b/api/report/search/creative.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Creative 创意报告

--- a/api/report/search/keyword.go
+++ b/api/report/search/keyword.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Keyword 关键词报告

--- a/api/report/search/landingPage.go
+++ b/api/report/search/landingPage.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // LandingPage 落地页报告

--- a/api/report/search/overall.go
+++ b/api/report/search/overall.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Overall 搜索整体账户报告

--- a/api/report/search/product.go
+++ b/api/report/search/product.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Product 搜索商品报告

--- a/api/report/search/queryWord.go
+++ b/api/report/search/queryWord.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // QueryWord 搜索词报告

--- a/api/report/search/visitor.go
+++ b/api/report/search/visitor.go
@@ -1,10 +1,10 @@
 package search
 
 import (
-	reportApi "github.com/bububa/baidu-marketing/api/report"
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/report"
+	reportApi "github.com/xiaoshouchen/baidu-marketing/api/report"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/report"
 )
 
 // Visitor 搜索访客明细报告

--- a/api/search/account/getAccountInfo.go
+++ b/api/search/account/getAccountInfo.go
@@ -1,9 +1,9 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/account"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/account"
 )
 
 // GetAccountInfo 查询账户

--- a/api/search/account/updateAccountInfo.go
+++ b/api/search/account/updateAccountInfo.go
@@ -1,9 +1,9 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/account"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/account"
 )
 
 // UpdateAccountInfo 更新账户

--- a/api/search/adgroup/addAdgroup.go
+++ b/api/search/adgroup/addAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/adgroup"
 )
 
 // AddAdgroup 添加单元

--- a/api/search/adgroup/deleteAdgroup.go
+++ b/api/search/adgroup/deleteAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/adgroup"
 )
 
 // DeleteAdgroup 删除单元

--- a/api/search/adgroup/getAdgroup.go
+++ b/api/search/adgroup/getAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/adgroup"
 )
 
 // GetAdgroup 查询单元

--- a/api/search/adgroup/updateAdgroup.go
+++ b/api/search/adgroup/updateAdgroup.go
@@ -1,9 +1,9 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/adgroup"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/adgroup"
 )
 
 // UpdateAdgroup 更新单元

--- a/api/search/app/addAdgroupAppBind.go
+++ b/api/search/app/addAdgroupAppBind.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/app"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/app"
 )
 
 // AddAdgroupAppBind 添加APP绑定

--- a/api/search/app/deleteAdgroupAppBind.go
+++ b/api/search/app/deleteAdgroupAppBind.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/app"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/app"
 )
 
 // DeleteAdgroupAppBind 删除APP绑定

--- a/api/search/app/getAdgroupAppBind.go
+++ b/api/search/app/getAdgroupAppBind.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/app"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/app"
 )
 
 // GetAdgroupAppBind 查询APP绑定

--- a/api/search/app/getAppList.go
+++ b/api/search/app/getAppList.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/app"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/app"
 )
 
 // GetAppList 获取APP素材

--- a/api/search/campaign/addCampaign.go
+++ b/api/search/campaign/addCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/campaign"
 )
 
 // AddCampaign 添加计划

--- a/api/search/campaign/deleteCampaign.go
+++ b/api/search/campaign/deleteCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/campaign"
 )
 
 // DeleteCampaign 删除计划

--- a/api/search/campaign/getBindBusinessPointList.go
+++ b/api/search/campaign/getBindBusinessPointList.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/campaign"
 )
 
 // GetBindBusinessPointList 查询计划已使用的推广业务

--- a/api/search/campaign/getCampaign.go
+++ b/api/search/campaign/getCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/campaign"
 )
 
 // GetCampaign 查询计划

--- a/api/search/campaign/updateCampaign.go
+++ b/api/search/campaign/updateCampaign.go
@@ -1,9 +1,9 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/campaign"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/campaign"
 )
 
 // UpdateCampaign 更新计划

--- a/api/search/creative/addCreative.go
+++ b/api/search/creative/addCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/creative"
 )
 
 // AddCreative 添加基础创意

--- a/api/search/creative/deleteCreative.go
+++ b/api/search/creative/deleteCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/creative"
 )
 
 // DeleteCreative 删除基础创意

--- a/api/search/creative/getCreative.go
+++ b/api/search/creative/getCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/creative"
 )
 
 // GetCreative 查询基础创意

--- a/api/search/creative/updateCreative.go
+++ b/api/search/creative/updateCreative.go
@@ -1,9 +1,9 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/creative"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/creative"
 )
 
 // UpdateCreative 更新基础创意

--- a/api/search/keyword/addWord.go
+++ b/api/search/keyword/addWord.go
@@ -1,9 +1,9 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/keyword"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/keyword"
 )
 
 // AddWord 添加关键词

--- a/api/search/keyword/deleteWord.go
+++ b/api/search/keyword/deleteWord.go
@@ -1,9 +1,9 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/keyword"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/keyword"
 )
 
 // DeleteWord 删除关键词

--- a/api/search/keyword/getWord.go
+++ b/api/search/keyword/getWord.go
@@ -1,9 +1,9 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/keyword"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/keyword"
 )
 
 // GetWord 查询关键词

--- a/api/search/keyword/updateWord.go
+++ b/api/search/keyword/updateWord.go
@@ -1,9 +1,9 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/core"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/model/search/keyword"
+	"github.com/xiaoshouchen/baidu-marketing/core"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/model/search/keyword"
 )
 
 // UpdateWord 更新关键词

--- a/core/client.go
+++ b/core/client.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bububa/baidu-marketing/core/internal/debug"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/core/internal/debug"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 var (

--- a/core/internal/debug/debug.go
+++ b/core/internal/debug/debug.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 func PrintError(err error, debug bool) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bububa/baidu-marketing
+module github.com/xiaoshouchen/baidu-marketing
 
 go 1.20

--- a/model/account/balance/getAccountTransferHistory.go
+++ b/model/account/balance/getAccountTransferHistory.go
@@ -1,8 +1,8 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAccountTransferHistoryRequest 查询转账记录 API Request

--- a/model/account/balance/getBalanceInfo.go
+++ b/model/account/balance/getBalanceInfo.go
@@ -1,8 +1,8 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetBalanceInfoRequest 查询账户余额成分 API Request

--- a/model/account/balance/getPaymentHistory.go
+++ b/model/account/balance/getPaymentHistory.go
@@ -1,8 +1,8 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetPaymentHistoryRequest 查询待加款信息

--- a/model/account/balance/getPaymentRecordRequest.go
+++ b/model/account/balance/getPaymentRecordRequest.go
@@ -1,8 +1,8 @@
 package balance
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetPaymentRecordRequest 查询付款信息与待加款信息 API Request

--- a/model/account/getUserListByMccid.go
+++ b/model/account/getUserListByMccid.go
@@ -1,8 +1,8 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetUserListByMccidRequest 账户管家子账号 API Request

--- a/model/asset/image/getImage.go
+++ b/model/asset/image/getImage.go
@@ -1,8 +1,8 @@
 package image
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetImageRequest 获取图片素材API Request

--- a/model/asset/newimage/getImage.go
+++ b/model/asset/newimage/getImage.go
@@ -1,8 +1,8 @@
 package newimage
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetImageRequest （新图片服务（ImageManageService）打通了搜索图库与信息流图库）获取图片素材API Request

--- a/model/asset/newimage/uploadImage.go
+++ b/model/asset/newimage/uploadImage.go
@@ -1,8 +1,8 @@
 package newimage
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UploadImageRequest 上传图片素材API Request

--- a/model/asset/video/getVideo.go
+++ b/model/asset/video/getVideo.go
@@ -1,8 +1,8 @@
 package video
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetVideoRequest 获取视频素材 API Request

--- a/model/feed/account/getAccountFeed.go
+++ b/model/feed/account/getAccountFeed.go
@@ -1,8 +1,8 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAccountFeedRequest 查询账户信息 API Request

--- a/model/feed/account/updateAccountFeed.go
+++ b/model/feed/account/updateAccountFeed.go
@@ -1,8 +1,8 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateAccountFeedRequest 更新账户信息 API Request

--- a/model/feed/adgroup/addAdgroup.go
+++ b/model/feed/adgroup/addAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddAdgroupRequest 添加单元 API Request

--- a/model/feed/adgroup/deleteAdgroup.go
+++ b/model/feed/adgroup/deleteAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteAdgroupRequest 删除单元 API Request

--- a/model/feed/adgroup/getAdgroupFeed.go
+++ b/model/feed/adgroup/getAdgroupFeed.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAdgroupFeedRequest 查询推广单元 API Request

--- a/model/feed/adgroup/trans/addOcpcTransFeed.go
+++ b/model/feed/adgroup/trans/addOcpcTransFeed.go
@@ -1,8 +1,8 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddOcpcTransFeedRequest 添加转化追踪 API Request

--- a/model/feed/adgroup/trans/getOcpcTransFeedRequest.go
+++ b/model/feed/adgroup/trans/getOcpcTransFeedRequest.go
@@ -1,8 +1,8 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetOcpcTransFeedRequest 查询转化追踪 API Request

--- a/model/feed/adgroup/trans/updateOcpcTransFeed.go
+++ b/model/feed/adgroup/trans/updateOcpcTransFeed.go
@@ -1,8 +1,8 @@
 package trans
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateOcpcTransFeedRequest 更新转化追踪 API Request

--- a/model/feed/adgroup/updateAdgroup.go
+++ b/model/feed/adgroup/updateAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateAdgroupRequest 更新推广单元 API Request

--- a/model/feed/campaign/addCampaign.go
+++ b/model/feed/campaign/addCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddCampaignRequest 添加计划 API Request

--- a/model/feed/campaign/campaign.go
+++ b/model/feed/campaign/campaign.go
@@ -1,6 +1,6 @@
 package campaign
 
-import "github.com/bububa/baidu-marketing/model"
+import "github.com/xiaoshouchen/baidu-marketing/model"
 
 // Campaign 计划对象
 type Campaign struct {

--- a/model/feed/campaign/deleteCampaign.go
+++ b/model/feed/campaign/deleteCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteCampaignRequest 删除计划 API Request

--- a/model/feed/campaign/getCampaignFeed.go
+++ b/model/feed/campaign/getCampaignFeed.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetCampaignFeedRequest 查询计划 API Request

--- a/model/feed/campaign/getJsKpAppList.go
+++ b/model/feed/campaign/getJsKpAppList.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetJsKpAppListRequest 查询APP信息 API Request

--- a/model/feed/campaign/updateCampaign.go
+++ b/model/feed/campaign/updateCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateCampaignRequest 更新计划 API Request

--- a/model/feed/creative/addCreative.go
+++ b/model/feed/creative/addCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddCreativeRequest 新增推广创意 API Request

--- a/model/feed/creative/deleteCreative.go
+++ b/model/feed/creative/deleteCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteCreativeRequest 删除推广创意 API Request

--- a/model/feed/creative/getCreative.go
+++ b/model/feed/creative/getCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetCreativeRequest 查询创意 API Request

--- a/model/feed/creative/updateCreative.go
+++ b/model/feed/creative/updateCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateCreativeRequest 修改推广创意 API Request

--- a/model/oauth/accessToken.go
+++ b/model/oauth/accessToken.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AccessToken 授权令牌

--- a/model/oauth/getUserInfo.go
+++ b/model/oauth/getUserInfo.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetUserInfoRequest 查询授权用户信息

--- a/model/oauth/refreshToken.go
+++ b/model/oauth/refreshToken.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // RefreshTokenRequest 更新授权令牌接口

--- a/model/oauth/url.go
+++ b/model/oauth/url.go
@@ -1,8 +1,8 @@
 package oauth
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // URLRequest 程序化拼接授权链接 API Request

--- a/model/ocpc/actionCb.go
+++ b/model/ocpc/actionCb.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bububa/baidu-marketing/enum"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/enum"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // ActionCbRequest 转化追踪回调 请求

--- a/model/ocpc/uploadConvertDataRequest.go
+++ b/model/ocpc/uploadConvertDataRequest.go
@@ -1,8 +1,8 @@
 package ocpc
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UploadConvertDataRequest 广告主回传转化数据 API Request

--- a/model/ocpc/uploadInvalidConvertDataRequest.go
+++ b/model/ocpc/uploadInvalidConvertDataRequest.go
@@ -1,8 +1,8 @@
 package ocpc
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UploadInvalidConvertDataRequest

--- a/model/report/createReportTask.go
+++ b/model/report/createReportTask.go
@@ -1,9 +1,9 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/enum"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/enum"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // CreateReportTaskRequest 创建异步任务 API Request

--- a/model/report/dimension.go
+++ b/model/report/dimension.go
@@ -1,8 +1,8 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/enum"
-	"github.com/bububa/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/enum"
+	"github.com/xiaoshouchen/baidu-marketing/model"
 )
 
 // Dimension 维度

--- a/model/report/getReportData.go
+++ b/model/report/getReportData.go
@@ -1,9 +1,9 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/enum"
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/enum"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetReportDataRequest 一站式多渠道报告 API Request

--- a/model/report/getReportData.go
+++ b/model/report/getReportData.go
@@ -52,7 +52,7 @@ type Filter struct {
 
 // GetReportDataResponse 一站式多渠道报告 API Response
 type GetReportDataResponse struct {
-	Data *ReportData `json:"data,omitempty"`
+	Data []ReportData `json:"data,omitempty"`
 }
 
 type ReportData struct {

--- a/model/report/getTaskStatus.go
+++ b/model/report/getTaskStatus.go
@@ -1,8 +1,8 @@
 package report
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetTaskStatusRequest 获取异步任务状态 API Request

--- a/model/response.go
+++ b/model/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // ResponseHeader API 返回header对象

--- a/model/search/account/account.go
+++ b/model/search/account/account.go
@@ -1,6 +1,6 @@
 package account
 
-import "github.com/bububa/baidu-marketing/model"
+import "github.com/xiaoshouchen/baidu-marketing/model"
 
 // Account 账户信息
 type Account struct {

--- a/model/search/account/getAccountInfo.go
+++ b/model/search/account/getAccountInfo.go
@@ -1,8 +1,8 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAccountInfoRequest 查询账户 API Request

--- a/model/search/account/updateAccountInfo.go
+++ b/model/search/account/updateAccountInfo.go
@@ -1,8 +1,8 @@
 package account
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateAccountInfoRequest 更新账户 API Request

--- a/model/search/adgroup/addAdgroup.go
+++ b/model/search/adgroup/addAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddAdgroupRequest 添加单元 API Request

--- a/model/search/adgroup/deleteAdgroup.go
+++ b/model/search/adgroup/deleteAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteAdgroupRequest 删除单元 API Request

--- a/model/search/adgroup/getAdgroup.go
+++ b/model/search/adgroup/getAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAdgroupRequest 查询推广单元API Request

--- a/model/search/adgroup/updateAdgroup.go
+++ b/model/search/adgroup/updateAdgroup.go
@@ -1,8 +1,8 @@
 package adgroup
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateAdgroupRequest 更新推广单元 API Request

--- a/model/search/app/addAdgroupAppBind.go
+++ b/model/search/app/addAdgroupAppBind.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddAdgroupAppBindRequest 添加APP绑定 API Request

--- a/model/search/app/deleteAdgroupAppBind.go
+++ b/model/search/app/deleteAdgroupAppBind.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteAdgroupAppBindRequest 删除APP绑定 API Request

--- a/model/search/app/getAdgroupAppBind.go
+++ b/model/search/app/getAdgroupAppBind.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAdgroupAppBindRequest 查询APP绑定

--- a/model/search/app/getAppList.go
+++ b/model/search/app/getAppList.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetAppListRequest 获取APP素材 API Request

--- a/model/search/campaign/addCampaign.go
+++ b/model/search/campaign/addCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddCampaignRequest 添加计划 API Request

--- a/model/search/campaign/campaign.go
+++ b/model/search/campaign/campaign.go
@@ -1,6 +1,6 @@
 package campaign
 
-import "github.com/bububa/baidu-marketing/model"
+import "github.com/xiaoshouchen/baidu-marketing/model"
 
 // Campaign 推广计划
 type Campaign struct {

--- a/model/search/campaign/deleteCampaign.go
+++ b/model/search/campaign/deleteCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteCampaignRequest 删除计划 API Request

--- a/model/search/campaign/getBindBussinessPointList.go
+++ b/model/search/campaign/getBindBussinessPointList.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetBindBusinessPointListRequest 查询计划已使用的推广业务 API Request

--- a/model/search/campaign/getCampaign.go
+++ b/model/search/campaign/getCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetCampaignRequest 查询计划 API Request

--- a/model/search/campaign/updateCampaign.go
+++ b/model/search/campaign/updateCampaign.go
@@ -1,8 +1,8 @@
 package campaign
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateCampaignRequest 更新计划 API Request

--- a/model/search/creative/addCreative.go
+++ b/model/search/creative/addCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddCreativeRequest 添加基础创意 API Request

--- a/model/search/creative/creative.go
+++ b/model/search/creative/creative.go
@@ -1,6 +1,6 @@
 package creative
 
-import "github.com/bububa/baidu-marketing/model"
+import "github.com/xiaoshouchen/baidu-marketing/model"
 
 // Creative 推广创意
 type Creative struct {

--- a/model/search/creative/deleteCreative.go
+++ b/model/search/creative/deleteCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteCreativeRequest 删除基础创意 API Request

--- a/model/search/creative/getCreative.go
+++ b/model/search/creative/getCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetCreativeRequest 查询推广创意 API Request

--- a/model/search/creative/updateCreative.go
+++ b/model/search/creative/updateCreative.go
@@ -1,8 +1,8 @@
 package creative
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateCreativeRequest 更新基础创意 API Request

--- a/model/search/keyword/addWord.go
+++ b/model/search/keyword/addWord.go
@@ -1,8 +1,8 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // AddWordRequest 添加关键词 API Request

--- a/model/search/keyword/deleteWord.go
+++ b/model/search/keyword/deleteWord.go
@@ -1,8 +1,8 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // DeleteWordRequest 删除关键词 API Request

--- a/model/search/keyword/getWord.go
+++ b/model/search/keyword/getWord.go
@@ -1,8 +1,8 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // GetWordRequest 查询关键词 API Request

--- a/model/search/keyword/keyword.go
+++ b/model/search/keyword/keyword.go
@@ -1,6 +1,6 @@
 package keyword
 
-import "github.com/bububa/baidu-marketing/model"
+import "github.com/xiaoshouchen/baidu-marketing/model"
 
 // Keyword 关键词对象
 type Keyword struct {

--- a/model/search/keyword/updateWord.go
+++ b/model/search/keyword/updateWord.go
@@ -1,8 +1,8 @@
 package keyword
 
 import (
-	"github.com/bububa/baidu-marketing/model"
-	"github.com/bububa/baidu-marketing/util"
+	"github.com/xiaoshouchen/baidu-marketing/model"
+	"github.com/xiaoshouchen/baidu-marketing/util"
 )
 
 // UpdateWordRequest 更新关键词 API Request


### PR DESCRIPTION
修复 “json: cannot unmarshal array into Go struct field GetReportDataResponse.data of type report.ReportData
” 的报错问题

截图是百度的返回数据

<img width="506" alt="image" src="https://github.com/bububa/baidu-marketing/assets/14228813/9b7dd681-bed8-4205-8f85-ba2554154ca6">

请注意，这里data是一个array而不是object